### PR TITLE
Enable native compile with GraalVM 24+

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ IMPORTANT: Do not use SDKMan because this will fall back to the x86 version of t
 mvn clean package
 ```
 
+## Build in native image
+
+Use a GraalVM JDK 24 or higher (tested with Graal 24, ea 30)
+
+```
+./mvnw -Pnative native:compile
+```
+
+This will produce `./target/llama3-server`. This does not work on MacOS because there is no Vector
+API support on Graal + MacOS.
+
 ## Download LLM
 
 Download a GGUF model from the Hugging Face model hub and place it in the 'models' directory. 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.5.0-M1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -17,7 +17,7 @@
     <description>REST API wrapper for Llama model</description>
 
     <properties>
-        <java.version>23</java.version>
+        <java.version>24</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -73,7 +73,6 @@
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -116,6 +115,31 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
                     <jvmArguments>--add-modules jdk.incubator.vector --enable-preview</jvmArguments>
+                    <compilerArguments>--enable-preview -g --add-modules jdk.incubator.vector</compilerArguments>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.graalvm.buildtools</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <configuration>
+                    <buildArgs>
+                        <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
+                        <buildArg>-H:+VectorAPISupport</buildArg>
+                        <buildArg>-H:+ForeignAPISupport</buildArg>
+<!--                        <buildArg>-Ob</buildArg>-->
+                        <buildArg>-O3</buildArg>
+                        <buildArg>-march=native</buildArg>
+                        <buildArg>--verbose</buildArg>
+                        <buildArg>--emit</buildArg>
+                        <buildArg>build-report</buildArg>
+                        <buildArg>--enable-preview</buildArg>
+                        <buildArg>--add-modules</buildArg>
+                        <buildArg>jdk.incubator.vector</buildArg>
+                        <buildArg>--initialize-at-build-time=com.llama4j.core.FloatTensor,com.llama4j.core.Llama,com.llama4j.core.ModelLoader,com.llama4j.core.</buildArg>
+                        <buildArg>-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=0</buildArg>
+                        <buildArg>-Dllama.PreloafGGUF=./models/</buildArg>
+                    </buildArgs>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/llama4j/Main.java
+++ b/src/main/java/com/llama4j/Main.java
@@ -1,8 +1,10 @@
 package com.llama4j;
 
+import com.llama4j.dto.ChatCompletionResponse;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -13,8 +15,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 
-@EnableConfigurationProperties
 @SpringBootApplication
+@RegisterReflectionForBinding(ChatCompletionResponse.class)
 public class Main {
 
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);

--- a/src/main/java/com/llama4j/core/FloatTensor.java
+++ b/src/main/java/com/llama4j/core/FloatTensor.java
@@ -3,8 +3,6 @@ package com.llama4j.core;
 import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.VectorSpecies;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import sun.misc.Unsafe;
 
 import java.lang.foreign.MemorySegment;
@@ -19,7 +17,6 @@ import java.util.Arrays;
  */
 public abstract class FloatTensor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FloatTensor.class);
 
     static final boolean USE_VECTOR_API = Boolean.parseBoolean(System.getProperty("llama.VectorAPI", "true"));
 
@@ -35,7 +32,6 @@ public abstract class FloatTensor {
             f.setAccessible(true);
             UNSAFE = (Unsafe) f.get(null);
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            LOG.error("Failed to access Unsafe", e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/llama4j/core/Llama.java
+++ b/src/main/java/com/llama4j/core/Llama.java
@@ -1,8 +1,6 @@
 package com.llama4j.core;
 
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.FloatBuffer;
 import java.util.ArrayList;
@@ -13,7 +11,6 @@ import java.util.stream.Stream;
 
 public record Llama(Configuration configuration, Tokenizer tokenizer, Weights weights) {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Llama.class);
 
     public @NotNull State createNewState() {
         State state = new State(configuration());
@@ -293,7 +290,7 @@ public record Llama(Configuration configuration, Tokenizer tokenizer, Weights we
                                                         Sampler sampler,
                                                         boolean echo,
                                                         IntConsumer onTokenGenerated) {
-        LOG.debug("Generating tokens from position {}", startPosition);
+        System.out.printf("Generating tokens from position %s%n", startPosition);
         long startNanos = System.nanoTime();
         if (maxTokens < 0 || model.configuration().contextLength < maxTokens) {
             maxTokens = model.configuration().contextLength;
@@ -303,7 +300,7 @@ public record Llama(Configuration configuration, Tokenizer tokenizer, Weights we
         int nextToken;
         int promptIndex = 0;
 
-        LOG.debug("Using {}", state.logits);
+        System.out.printf("Using %s%n", state.logits);
 
         for (int position = startPosition; position < maxTokens; ++position) {
             forward(model, state, token, position);
@@ -313,13 +310,13 @@ public record Llama(Configuration configuration, Tokenizer tokenizer, Weights we
                 nextToken = promptTokens.get(promptIndex++);
                 if (echo) {
                     // log prompt token (different color?)
-                    LOG.error(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
+                    System.err.println(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
                 }
             } else {
                 nextToken = sampler.sampleToken(state.logits);
                 if (echo) {
                     // log inferred token
-                    LOG.error(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
+                    System.err.println(Tokenizer.replaceControlCharacters(model.tokenizer().decode(List.of(nextToken))));
                 }
                 generatedTokens.add(nextToken);
                 if (onTokenGenerated != null) {
@@ -332,7 +329,7 @@ public record Llama(Configuration configuration, Tokenizer tokenizer, Weights we
             state.latestToken = token = nextToken;
 
             if (position % 50 == 0) {
-                LOG.debug("Progress: {} tokens generated", position);
+                System.out.printf("Progress: %s tokens generated%n", position);
             }
         }
 
@@ -340,7 +337,7 @@ public record Llama(Configuration configuration, Tokenizer tokenizer, Weights we
         int totalTokens = promptIndex + generatedTokens.size();
 
         String tokensMsg = String.format("%n%.2f tokens/s (%d)", totalTokens / (elapsedNanos / 1_000_000_000.0), totalTokens);
-        LOG.debug(tokensMsg);
+        System.out.println(tokensMsg);
 
         return generatedTokens;
     }

--- a/src/main/java/com/llama4j/core/Llama3.java
+++ b/src/main/java/com/llama4j/core/Llama3.java
@@ -7,8 +7,6 @@ import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.foreign.Arena;
@@ -30,10 +28,9 @@ import java.util.stream.IntStream;
 
 public class Llama3 {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Llama3.class);
 
     public static Sampler selectSampler(int vocabularySize, float temperature, float topp, long rngSeed) {
-        LOG.debug("Creating sampler with temperature={}, topp={}, seed={}", temperature, topp, rngSeed);
+        System.out.printf("Creating sampler with temperature=%s, topp=%s, seed=%s%n", temperature, topp, rngSeed);
 
         Sampler sampler;
         if (temperature == 0.0f) {
@@ -72,7 +69,7 @@ public class Llama3 {
         int startPosition = 0;
         Scanner in = new Scanner(System.in);
         while (true) {
-            LOG.debug("> ");
+            System.out.println("> ");
             String userText = in.nextLine();
             if (List.of("quit", "exit").contains(userText)) {
                 break;
@@ -86,7 +83,7 @@ public class Llama3 {
             List<Integer> responseTokens = Llama.generateTokens(model, state, startPosition, conversationTokens.subList(startPosition, conversationTokens.size()), stopTokens, options.maxTokens(), sampler, options.echo(), token -> {
                 if (options.stream()) {
                     if (model.tokenizer().isNotSpecialToken(token)) {
-                        LOG.debug(model.tokenizer().decode(List.of(token)));
+                        System.out.println(model.tokenizer().decode(List.of(token)));
                     }
                 }
             });
@@ -100,10 +97,10 @@ public class Llama3 {
             }
             if (!options.stream()) {
                 String responseText = model.tokenizer().decode(responseTokens);
-                LOG.debug(responseText);
+                System.out.println(responseText);
             }
             if (stopToken == null) {
-                LOG.error("Ran out of context length...");
+                System.err.println("Ran out of context length...");
                 break;
             }
         }
@@ -119,7 +116,7 @@ public class Llama3 {
     public static @NotNull RequestResponse runInstructOnce(@NotNull Llama model,
                                                   Sampler sampler,
                                                   @NotNull Options options) {
-        LOG.debug("Running instruct once");
+        System.out.println("Running instruct once");
         StringBuffer buffer = new StringBuffer();
         Llama.State state = model.createNewState();
         ChatFormat chatFormat = new ChatFormat(model.tokenizer());
@@ -136,12 +133,12 @@ public class Llama3 {
         List<Integer> responseTokens = Llama.generateTokens(model, state, 0, promptTokens, stopTokens, options.maxTokens(), sampler, options.echo(), token -> {
             String decode = model.tokenizer().decode(List.of(token));
             buffer.append(decode);
-            LOG.debug(decode);
+            System.out.println(decode);
 
             // TODO Double check if this is still required when using buffer.append ?
 //            if (options.stream()) {
 //                if (model.tokenizer().isNotSpecialToken(token)) {
-//                    LOG.debug(decode);
+//                    soutcode);
 //                }
 //            }
         });
@@ -152,7 +149,7 @@ public class Llama3 {
 
         if (!options.stream()) {
             String responseText = model.tokenizer().decode(responseTokens);
-            LOG.debug(responseText);
+            System.out.println(responseText);
         }
 
         return new RequestResponse(responseTokens.size(), buffer.toString());
@@ -537,7 +534,6 @@ final class GGUF {
 }
 
 interface Timer extends AutoCloseable {
-    Logger LOGGER = LoggerFactory.getLogger(Timer.class);
 
     @Override
     void close(); // no Exception
@@ -555,7 +551,7 @@ interface Timer extends AutoCloseable {
             @Override
             public void close() {
                 long elapsedNanos = System.nanoTime() - startNanos;
-                LOGGER.debug("{}: {} {}",
+                System.out.printf("%s: %s %s%n",
                     label,
                     timeUnit.convert(elapsedNanos, TimeUnit.NANOSECONDS),
                     timeUnit.toChronoUnit().name().toLowerCase());

--- a/src/main/java/com/llama4j/web/rest/LlamaWrapperApplication.java
+++ b/src/main/java/com/llama4j/web/rest/LlamaWrapperApplication.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.llama4j.core.Llama3.*;
 
-@SpringBootApplication
 @RestController
 public class LlamaWrapperApplication {
 


### PR DESCRIPTION
This PR enables native-image compilation using GraalVM, 24 or higher.

Notes on the PR:
1. Uses Boot 3.5-M1
1. Stole the correct flags for native compile from the original [llama3.java](https://github.com/mukel/llama3.java/)
1. It requires build-time init of some files. Those files have static slf4j loggers. It requires more work to make them work with "init at build time", so I scrapped those in the interest of making a PoC